### PR TITLE
One bug and small changes

### DIFF
--- a/src/otcurrentOverlayFactory.cpp
+++ b/src/otcurrentOverlayFactory.cpp
@@ -502,8 +502,6 @@ void otcurrentOverlayFactory::DrawGLLabels(otcurrentOverlayFactory *pof, wxDC *d
 
 wxImage &otcurrentOverlayFactory::DrawGLPolygon(){
 
-	wxString labels;
-	labels = _T("");  // dummy label for drawing with
 	wxImage	img;
 
 	wxColour c_orange = c_GLcolour;
@@ -513,11 +511,7 @@ wxImage &otcurrentOverlayFactory::DrawGLPolygon(){
 
     wxMemoryDC mdc(wxNullBitmap);
 
-    wxFont mfont( 9, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL );
-    mdc.SetFont( mfont );
-
     int w, h;
-    mdc.GetTextExtent(labels, &w, &h);
 	
 	w = 200;
 	h = 200;
@@ -531,8 +525,7 @@ wxImage &otcurrentOverlayFactory::DrawGLPolygon(){
     mdc.SetTextForeground(c_orange);
     mdc.SetTextBackground(c_orange);
           
-    int xd = 0;
-    int yd = 0;
+   // int xd = 0, yd = 0;
    // mdc.DrawRoundedRectangle(xd, yd, w+(label_offset * 2), h+2, -.25);
 /*
 		
@@ -647,13 +640,11 @@ void otcurrentOverlayFactory::drawGLPolygons(otcurrentOverlayFactory *pof, wxDC 
          } 
 		 else { /* opengl */
                   
-			int w = imageLabel.GetWidth(), h = imageLabel.GetHeight();
-
             unsigned char *d = imageLabel.GetData();
             unsigned char *a = imageLabel.GetAlpha();
 
             unsigned char mr, mg, mb;
-           if(!a && !imageLabel.GetOrFindMaskColour( &mr, &mg, &mb ) ) 
+            if(!a && !imageLabel.GetOrFindMaskColour( &mr, &mg, &mb ) ) 
                 wxMessageBox(_T("trying to use mask to draw a bitmap without alpha or mask\n" ));
 
             unsigned char *e = new unsigned char[4 * w * h];

--- a/src/otcurrentOverlayFactory.cpp
+++ b/src/otcurrentOverlayFactory.cpp
@@ -386,8 +386,8 @@ void otcurrentOverlayFactory::DrawOLBitmap( const wxBitmap &bitmap, wxCoord x, w
             unsigned char *a = image.GetAlpha();
 
             unsigned char mr, mg, mb;
-            if( !image.GetOrFindMaskColour( &mr, &mg, &mb ) && !a ) printf(
-                    "trying to use mask to draw a bitmap without alpha or mask\n" );
+            if(!a && !image.GetOrFindMaskColour( &mr, &mg, &mb ) ) 
+               printf("trying to use mask to draw a bitmap without alpha or mask\n" );
 
             unsigned char *e = new unsigned char[4 * w * h];
             {
@@ -464,15 +464,15 @@ void otcurrentOverlayFactory::DrawGLLabels(otcurrentOverlayFactory *pof, wxDC *d
             unsigned char *a = imageLabel.GetAlpha();
 
             unsigned char mr, mg, mb;
-            if( !imageLabel.GetOrFindMaskColour( &mr, &mg, &mb ) && !a ) wxMessageBox(_T(
-                    "trying to use mask to draw a bitmap without alpha or mask\n" ));
+            if( !a && !imageLabel.GetOrFindMaskColour( &mr, &mg, &mb ) ) 
+              wxMessageBox(_T("trying to use mask to draw a bitmap without alpha or mask\n" ));
 
             unsigned char *e = new unsigned char[4 * w * h];
             {
                 for( int y = 0; y < h; y++ )
                     for( int x = 0; x < w; x++ ) {
                         unsigned char r, g, b;
-                        int off = ( y * imageLabel.GetWidth() + x );
+                        int off = ( y * w + x );
                         r = d[off * 3 + 0];
                         g = d[off * 3 + 1];
                         b = d[off * 3 + 2];
@@ -656,15 +656,15 @@ void otcurrentOverlayFactory::drawGLPolygons(otcurrentOverlayFactory *pof, wxDC 
             unsigned char *a = imageLabel.GetAlpha();
 
             unsigned char mr, mg, mb;
-           if( !imageLabel.GetOrFindMaskColour( &mr, &mg, &mb ) && !a ) wxMessageBox(_T(
-                    "trying to use mask to draw a bitmap without alpha or mask\n" ));
+           if(!a && !imageLabel.GetOrFindMaskColour( &mr, &mg, &mb ) ) 
+                wxMessageBox(_T("trying to use mask to draw a bitmap without alpha or mask\n" ));
 
             unsigned char *e = new unsigned char[4 * w * h];
             {
                 for( int y = 0; y < h; y++ )
                     for( int x = 0; x < w; x++ ) {
                         unsigned char r, g, b;
-                        int off = ( y * imageLabel.GetWidth() + x );
+                        int off = ( y * w + x );
                         r = d[off * 3 + 0];
                         g = d[off * 3 + 1];
                         b = d[off * 3 + 2];

--- a/src/otcurrentOverlayFactory.cpp
+++ b/src/otcurrentOverlayFactory.cpp
@@ -176,7 +176,7 @@ wxColour otcurrentOverlayFactory::GetSpeedColour(double my_speed){
 	return wxColour(0, 0, 0);
 }
 
-void otcurrentOverlayFactory::drawCurrentArrow(int x, int y, double rot_angle, double scale, double rate )
+bool otcurrentOverlayFactory::drawCurrentArrow(int x, int y, double rot_angle, double scale, double rate )
 {   	
 	double m_rate = fabs(rate);
 	wxPoint p[9];
@@ -186,7 +186,7 @@ void otcurrentOverlayFactory::drawCurrentArrow(int x, int y, double rot_angle, d
 	
 	c_GLcolour = colour;  // for filling GL arrows
 	if( scale <= 1e-2 )
-	    return;
+	    return false;
 
 	wxBrush brush(colour);
 
@@ -249,7 +249,7 @@ void otcurrentOverlayFactory::drawCurrentArrow(int x, int y, double rot_angle, d
 		m_pdc->SetBrush(brush);
 		m_pdc->DrawPolygon(9,p);
 	}
-
+	return true;
 }
 
 wxImage &otcurrentOverlayFactory::DrawGLText( double value, int precision ){
@@ -786,16 +786,14 @@ void otcurrentOverlayFactory::DrawAllCurrentsInViewPort(PlugIn_ViewPort *BBox, b
                         double a2 = log10( a1 );
                         double scale = current_draw_scaler * a2;
 
-						drawCurrentArrow( pixxc, pixyc,	dir - 90 + rot_vp , scale/100, tcvalue );
+						bool rendered = drawCurrentArrow( pixxc, pixyc, dir -90 + rot_vp , scale/100, tcvalue );
                                
 						int shift = 0;
 
-						if(!m_pdc && m_bShowFillColour){
-							drawGLPolygons(this, m_pdc, BBox, DrawGLPolygon(), lat, lon, shift);
-						}
+						if ( !m_pdc ) {
+                           if (rendered && m_bShowFillColour) 
+							  drawGLPolygons(this, m_pdc, BBox, DrawGLPolygon(), lat, lon, shift);
 
-
-					   if (!m_pdc){
 						   if(m_bShowRate){
                           
 							  DrawGLLabels( this, m_pdc, BBox, 
@@ -810,14 +808,13 @@ void otcurrentOverlayFactory::DrawAllCurrentsInViewPort(PlugIn_ViewPort *BBox, b
 						   }
 						   if( m_bShowDirection){
 						  
-								DrawGLLabels( this, m_pdc, BBox, 
+							  DrawGLLabels( this, m_pdc, BBox, 
 											DrawGLTextDir(dir, 0), lat, lon, shift) ;
 						   }
-					   }			
-						char sbuf[20];					 
-					
-						if( m_bShowRate && m_pdc ) 
-						{
+					    }
+						else {
+						  char sbuf[20];
+                          if( m_bShowRate ) {
 							snprintf( sbuf, 19, "%3.1f", fabs(tcvalue) );
 							m_pdc->DrawText( wxString( sbuf, wxConvUTF8 ), pixxc, pixyc );
 							if (!m_bHighResolution){
@@ -826,17 +823,14 @@ void otcurrentOverlayFactory::DrawAllCurrentsInViewPort(PlugIn_ViewPort *BBox, b
 							else {
 								shift = 26;
 							}
-						}					 
+						  }
 					
-						if ( m_bShowDirection && m_pdc)	
-						{	
+						  if ( m_bShowDirection ) {	
 							snprintf( sbuf, 19, "%03.0f", dir );
 							m_pdc->DrawText( wxString( sbuf, wxConvUTF8 ), pixxc, pixyc + shift );
-						}
-
-
+                          }
+                        }
                     }
-                      
                   }
 
                 }

--- a/src/otcurrentOverlayFactory.cpp
+++ b/src/otcurrentOverlayFactory.cpp
@@ -185,17 +185,19 @@ void otcurrentOverlayFactory::drawCurrentArrow(int x, int y, double rot_angle, d
 	colour = GetSpeedColour( m_rate );
 	
 	c_GLcolour = colour;  // for filling GL arrows
+	if( scale <= 1e-2 )
+	    return;
 
-	wxPen pen( colour, 2 );
 	wxBrush brush(colour);
 
     if( m_pdc ) {
+	    wxPen pen( colour, 2 );
+
         m_pdc->SetPen( pen );
         m_pdc->SetBrush( brush);  
     }
 
    
-	if( scale > 1e-2 ) {
 
         float sin_rot = sin( rot_angle * PI / 180. );
         float cos_rot = cos( rot_angle * PI / 180. );
@@ -250,7 +252,6 @@ void otcurrentOverlayFactory::drawCurrentArrow(int x, int y, double rot_angle, d
 			m_pdc->DrawPolygon(9,p);
 		}
 
-    }
 }
 
 wxImage &otcurrentOverlayFactory::DrawGLText( double value, int precision ){

--- a/src/otcurrentOverlayFactory.cpp
+++ b/src/otcurrentOverlayFactory.cpp
@@ -277,7 +277,7 @@ wxImage &otcurrentOverlayFactory::DrawGLTextString( wxString myText ){
     it = m_labelCacheText.find(labels);
     if (it != m_labelCacheText.end())
         return it->second;
-                                    
+
 	wxMemoryDC mdc(wxNullBitmap);
 
     mdc.SetFont( *pTCFont);
@@ -291,14 +291,11 @@ wxImage &otcurrentOverlayFactory::DrawGLTextString( wxString myText ){
     mdc.SelectObject(bm);
     mdc.Clear();
 
-    wxColour text_color;
-
-    GetGlobalColor( _T ("UINFD" ), &text_color );
-    wxPen penText(text_color);
+    wxPen penText(m_text_color);
 	mdc.SetPen(penText);
 
     mdc.SetBrush(*wxTRANSPARENT_BRUSH);
-    mdc.SetTextForeground(text_color);
+    mdc.SetTextForeground(m_text_color);
     mdc.SetTextBackground(wxTRANSPARENT);
           
     int xd = 0;
@@ -328,7 +325,7 @@ wxImage &otcurrentOverlayFactory::DrawGLTextString( wxString myText ){
             a[ioff] = 255-(r+g+b)/3;
         }
     }
-    return m_labelCacheText[myText];
+    return image;
 }
 
 void otcurrentOverlayFactory::DrawGLLine( double x1, double y1, double x2, double y2, double width, wxColour myColour )
@@ -703,6 +700,14 @@ void otcurrentOverlayFactory::DrawAllCurrentsInViewPort(PlugIn_ViewPort *BBox, b
 	if (BBox->chart_scale > 1000000){
 		return;
 	}
+    wxColour text_color;
+
+    GetGlobalColor( _T ("UINFD" ), &text_color );
+    if (text_color != m_text_color) {
+       // color changed, invalid cache
+       m_text_color = text_color;
+       m_labelCacheText.clear();
+    }
 
     double rot_vp = BBox->rotation*180/M_PI;
 

--- a/src/otcurrentOverlayFactory.h
+++ b/src/otcurrentOverlayFactory.h
@@ -144,6 +144,7 @@ private:
     bool m_hiDefGraphics;
     bool m_bGradualColors;
 
+    wxColour m_text_color;
     std::map < double , wxImage > m_labelCache;
 	std::map < wxString , wxImage > m_labelCacheText;
 

--- a/src/otcurrentOverlayFactory.h
+++ b/src/otcurrentOverlayFactory.h
@@ -147,6 +147,7 @@ private:
     std::map < double , wxImage > m_labelCache;
 	std::map < wxString , wxImage > m_labelCacheText;
 
+	wxImage m_fillImg;
     otcurrentUIDialog &m_dlg;
 
 };

--- a/src/otcurrentOverlayFactory.h
+++ b/src/otcurrentOverlayFactory.h
@@ -120,7 +120,7 @@ private:
 
     wxColour GetSpeedColour(double my_speed);
 
-    void drawCurrentArrow(int x, int y, double rot_angle, double scale, double rate );
+    bool drawCurrentArrow(int x, int y, double rot_angle, double scale, double rate );
 
 
     double m_last_vp_scale;

--- a/src/tcmgr.cpp
+++ b/src/tcmgr.cpp
@@ -244,7 +244,7 @@ TCMgr::TCMgr(const wxString &data_dir, const wxString &home_dir)
 
 
 //    Load the Master Station Data Cache file
-      LoadMRU();
+      // LoadMRU();
 
       bTCMReady = true;
 error:
@@ -254,7 +254,7 @@ error:
 
 TCMgr::~TCMgr()
 {
-   SaveMRU();
+   //SaveMRU();
 
    FreeMRU();
 


### PR DESCRIPTION
Hi,

without b79f3c4 if an arrows isn't rendered (too low speed) otcurrent was using the last rendered arrow as mask.

The MRU wasn't used before (it's saved in DTOR which was never called). I'm not sure what MRU is for but it's removed from OPCN current main so keep it that way.